### PR TITLE
feat: Add GitHub Pages deployment workflow for /site folder

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,37 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'site/**'
+      - '.github/workflows/github-pages.yml'
+  workflow_dispatch:  # Allow manual trigger
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          publish_branch: gh-pages
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'Deploy website from /site folder'


### PR DESCRIPTION
## Summary

Implements GitHub Actions workflow to automatically deploy the `/site` folder to GitHub Pages using the `gh-pages` branch approach.

**Changes**:
- Added `.github/workflows/github-pages.yml` workflow
- Automatically deploys `/site` contents to `gh-pages` branch on push to `main`
- Supports manual workflow dispatch for on-demand deployments

**Why this approach**:
- GitHub Pages only supports root, `/docs`, or branches - not arbitrary subfolders like `/site`
- Using GitHub Actions allows us to keep our current structure (`/docs` for technical docs, `/site` for website)
- Standard industry practice for deploying from subfolders

## Configuration Required After Merge

1. Go to repository Settings → Pages
2. Set Source to "Deploy from a branch"
3. Select branch: `gh-pages` and folder: `/ (root)`
4. Save

## Test Plan

- [x] Created workflow file with proper permissions
- [x] Committed and pushed to feature branch
- [ ] Merge to main
- [ ] Verify workflow runs successfully
- [ ] Configure GitHub Pages settings
- [ ] Verify site is accessible at `https://joshuaaferguson.github.io/streamspace/`

## Related

Resolves the issue where GitHub Pages cannot serve from the `/site` subfolder directly.