### PR TITLE
fix(ci): Update GitHub Pages workflow to trigger on master branch

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -3,7 +3,7 @@ name: Deploy GitHub Pages
 on:
   push:
     branches:
-      - main
+      - master
     paths:
       - 'site/**'
       - '.github/workflows/github-pages.yml'


### PR DESCRIPTION
The repository uses 'master' as the default branch, not 'main'. This prevented the workflow from running automatically.