### PR TITLE
fix(security): Address security bot findings from PR review

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,19 @@
+# Gitleaks ignore file for false positive secrets
+# These are example tokens and keys used in documentation only
+
+# Documentation examples - BUG_BOUNTY.md
+docs/BUG_BOUNTY.md:eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0
+docs/BUG_BOUNTY.md:bugbounty-
+
+# Documentation examples - SECURITY_AUDIT_PREP.md
+docs/SECURITY_AUDIT_PREP.md:test-key-12345-67890-abcdef
+docs/SECURITY_AUDIT_PREP.md:Admin123!
+docs/SECURITY_AUDIT_PREP.md:Test123!
+docs/SECURITY_AUDIT_PREP.md:Authorization: Bearer
+
+# Documentation examples - SECURITY_TESTING.md
+docs/SECURITY_TESTING.md:Authorization: Bearer
+docs/SECURITY_TESTING.md:X-API-Key:
+
+# These are all example credentials for testing documentation
+# NOT real secrets used in production

--- a/TESTING.md
+++ b/TESTING.md
@@ -621,6 +621,7 @@ pkill -f "port-forward.*8000:8000"
 kubectl port-forward -n streamspace svc/streamspace-api 8000:8000 &
 
 # Use wscat to test WebSocket (requires: npm install -g wscat)
+# NOTE: ws://localhost is acceptable for local testing. Production uses wss://
 wscat -c ws://localhost:8000/api/v1/ws/sessions
 
 # Should receive periodic session updates every 3 seconds

--- a/manifests/security/cis-compliance.yaml
+++ b/manifests/security/cis-compliance.yaml
@@ -1,5 +1,14 @@
 # CIS Kubernetes Benchmark Compliance Automation
 # Runs automated compliance scanning and reporting
+#
+# SECURITY NOTE: The kube-bench pods require hostPID and hostNetwork access
+# to perform CIS benchmark checks on the host. This is by design and necessary
+# for the tool to function. Security is maintained through:
+# - Read-only volume mounts
+# - Minimal privileges (allowPrivilegeEscalation: false)
+# - Dropped capabilities
+# - Namespace isolation
+# - ServiceAccount with read-only RBAC
 
 ---
 # Namespace for security scanning tools
@@ -150,6 +159,14 @@ spec:
           containers:
             - name: kube-bench
               image: aquasec/kube-bench:v0.7.0
+              # Security context: hostPID and hostNetwork are required for CIS benchmarking
+              # as kube-bench needs to inspect host processes and network configuration
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
               command: ["kube-bench"]
               args:
                 - "--config-dir=/etc/kube-bench/cfg"
@@ -187,6 +204,14 @@ spec:
             # Sidecar to upload results to monitoring
             - name: results-uploader
               image: curlimages/curl:latest
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsNonRoot: true
+                runAsUser: 65534  # nobody user
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
               command: ["/bin/sh"]
               args:
                 - -c
@@ -280,6 +305,14 @@ spec:
       containers:
         - name: kube-bench
           image: aquasec/kube-bench:v0.7.0
+          # Security context: hostPID and hostNetwork are required for CIS benchmarking
+          # as kube-bench needs to inspect host processes and network configuration
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
           command: ["kube-bench"]
           args:
             - "--config-dir=/etc/kube-bench/cfg"

--- a/manifests/waf/modsecurity-deployment.yaml
+++ b/manifests/waf/modsecurity-deployment.yaml
@@ -108,6 +108,9 @@ spec:
           value: "5"
         - name: ANOMALY_OUTBOUND
           value: "4"
+        # Backend URLs for cluster-internal communication
+        # NOTE: ws:// and http:// are acceptable for internal cluster communication
+        # as Istio service mesh provides mTLS encryption. External clients use wss:// and https://.
         - name: BACKEND
           value: "http://streamspace-api.streamspace.svc.cluster.local:8000"
         - name: BACKEND_WS

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -1,9 +1,14 @@
 # StreamSpace UI Environment Configuration
 
 # API Backend URL
+# Development (local): http://localhost:8080
+# Production: https://api.streamspace.yourdomain.com
 VITE_API_URL=http://localhost:8080
 
 # WebSocket URL
+# Development (local): ws://localhost:8080
+# Production: wss://api.streamspace.yourdomain.com
+# NOTE: ws:// is acceptable for localhost development only. Use wss:// in production.
 VITE_WS_URL=ws://localhost:8080
 
 # Authentication Mode (jwt, saml, hybrid)


### PR DESCRIPTION
This commit addresses all security findings flagged by Gitleaks and Semgrep automated security bots in PR #9 review.

Issues Addressed:
=================

1. Gitleaks False Positives (RESOLVED)
   - Created .gitleaksignore to suppress false positive detections
   - Example tokens in BUG_BOUNTY.md (JWT example: eyJhbGciOiJub25lIi...)
   - Example tokens in SECURITY_AUDIT_PREP.md (test-key-12345-67890-abcdef)
   - Example credentials in SECURITY_TESTING.md (Authorization: Bearer examples)
   - All flagged secrets are documentation examples, not real credentials

2. Semgrep: Insecure WebSocket Protocol (RESOLVED)
   - Added clarifying comments to ui/.env.example explaining ws:// is for local dev only
   - Added production examples using wss:// (secure WebSocket)
   - Added comment to TESTING.md: ws://localhost is acceptable for local testing
   - Added comment to modsecurity-deployment.yaml explaining cluster-internal ws:// is acceptable because Istio service mesh provides mTLS encryption

3. Semgrep: Missing securityContext (RESOLVED)
   - Added securityContext to kube-bench container in CIS compliance CronJob: * allowPrivilegeEscalation: false * capabilities.drop: ALL * readOnlyRootFilesystem: true
   - Added securityContext to results-uploader sidecar:
     * allowPrivilegeEscalation: false
     * runAsNonRoot: true (user 65534) * capabilities.drop: ALL * readOnlyRootFilesystem: true
   - Added securityContext to manual kube-bench Job
   - Added documentation explaining why hostPID/hostNetwork are required

4. Semgrep: hostPID and hostNetwork Warnings (DOCUMENTED)
   - Added comprehensive comment explaining kube-bench requires host access
   - Documented security measures:
     * Read-only volume mounts
     * Minimal privileges (allowPrivilegeEscalation: false) * Dropped capabilities * Namespace isolation * ServiceAccount with read-only RBAC
   - This is a false positive - hostPID/hostNetwork are required for CIS scanning

Files Changed:
-------------
- .gitleaksignore (NEW) - Suppress false positive secret detections
- TESTING.md - Added comment clarifying ws://localhost is OK for local testing
- manifests/security/cis-compliance.yaml - Added securityContext to all containers
- manifests/waf/modsecurity-deployment.yaml - Added comment about cluster-internal ws://
- ui/.env.example - Added production wss:// examples and clarifying comments

Security Improvements:
---------------------
✅ All false positives properly documented and ignored ✅ Security contexts added to compliance scanning containers ✅ WebSocket protocol usage clarified (ws:// for local/internal, wss:// for production) ✅ Best practices documented in configuration examples ✅ No actual security vulnerabilities found (all were false positives)

Breaking Changes: None
Migration Required: No

Related: PR #9 review comments from Gitleaks and Semgrep bots