### PR TITLE
Fix GitHub Pages branch not updating

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -3,7 +3,7 @@ name: Deploy GitHub Pages
 on:
   push:
     branches:
-      - main
+      - master
     paths:
       - 'site/**'
       - '.github/workflows/github-pages.yml'


### PR DESCRIPTION
The workflow was configured to trigger on 'main' branch, but the repository's default branch is 'master'. This prevented the workflow from running automatically when site/ content was updated.

This fix ensures the gh-pages branch will be updated whenever changes are pushed to site/ on the master branch.