### PR TITLE
Update repository references to main branch

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -3,7 +3,7 @@ name: Deploy GitHub Pages
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - 'site/**'
       - '.github/workflows/github-pages.yml'

--- a/.github/workflows/image-signing.yml
+++ b/.github/workflows/image-signing.yml
@@ -5,14 +5,14 @@ name: Sign Container Images
 
 on:
   push:
-    branches: [main, master]
+    branches: [main]
     paths:
       - 'api/**'
       - 'controller/**'
       - 'ui/**'
       - '.github/workflows/image-signing.yml'
   pull_request:
-    branches: [main, master]
+    branches: [main]
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,10 +93,10 @@ jobs:
 
           ## Documentation
 
-          - [Installation Guide](https://github.com/${{ github.repository }}/blob/master/README.md)
-          - [Architecture Docs](https://github.com/${{ github.repository }}/blob/master/docs/ARCHITECTURE.md)
-          - [Controller Guide](https://github.com/${{ github.repository }}/blob/master/docs/CONTROLLER_GUIDE.md)
-          - [Helm Chart README](https://github.com/${{ github.repository }}/blob/master/chart/README.md)
+          - [Installation Guide](https://github.com/${{ github.repository }}/blob/main/README.md)
+          - [Architecture Docs](https://github.com/${{ github.repository }}/blob/main/docs/ARCHITECTURE.md)
+          - [Controller Guide](https://github.com/${{ github.repository }}/blob/main/docs/CONTROLLER_GUIDE.md)
+          - [Helm Chart README](https://github.com/${{ github.repository }}/blob/main/chart/README.md)
 
           ## Upgrade Instructions
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -2,9 +2,9 @@ name: Security Scanning
 
 on:
   push:
-    branches: [main, master]
+    branches: [main]
   pull_request:
-    branches: [main, master]
+    branches: [main]
   schedule:
     # Run daily at 2 AM UTC
     - cron: '0 2 * * *'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,7 @@ StreamSpace will become the leading open source alternative to commercial contai
 name: Build Container Images
 on:
   schedule: [cron: '0 0 * * 0']  # Weekly
-  push: {branches: [master]}
+  push: {branches: [main]}
 
 jobs:
   build-matrix:
@@ -720,12 +720,12 @@ make deploy IMG=your-registry/streamspace-controller:v0.1.0
 
 ### Branch Strategy
 
-**Main Branch**: `master` (protected)
+**Main Branch**: `main` (protected)
 
 **Feature Branches**:
 - Format: `claude/claude-md-<session-id>`
 - Example: `claude/claude-md-mhy5zeq2njvrp3yh-01MfcP2sWxBRw6sTTyEGW5gg`
-- Always develop on feature branches, not master
+- Always develop on feature branches, not main
 
 ### Commit Messages
 
@@ -797,7 +797,7 @@ git push -u origin claude/claude-md-<session-id>
 - Retry up to 4 times with exponential backoff (2s, 4s, 8s, 16s)
 
 **Pull Requests**:
-- Create PRs from feature branch to master
+- Create PRs from feature branch to main
 - Use PR template (see `CONTRIBUTING.md`)
 - Request review from maintainers
 - Ensure CI passes before merging

--- a/docs/SECURITY_IMPL_GUIDE.md
+++ b/docs/SECURITY_IMPL_GUIDE.md
@@ -569,7 +569,7 @@ name: SBOM Generation and Signing
 
 on:
   push:
-    branches: [main, master]
+    branches: [main]
     tags: ['v*']
   release:
     types: [published]

--- a/docs/SECURITY_TESTING.md
+++ b/docs/SECURITY_TESTING.md
@@ -172,7 +172,7 @@ kubectl delete sa test-user -n streamspace
 ## Automated Security Scanning
 
 StreamSpace uses GitHub Actions for automated security scanning. The workflow runs on:
-- Every push to main/master
+- Every push to main
 - Every pull request
 - Daily at 2 AM UTC
 - Manual trigger via workflow_dispatch

--- a/manifests/templates/README.md
+++ b/manifests/templates/README.md
@@ -47,4 +47,4 @@ kubectl apply -f https://raw.githubusercontent.com/JoshuaAFerguson/streamspace-t
 
 ## Adding Custom Templates
 
-To add your own templates, see the [Template Development Guide](https://github.com/JoshuaAFerguson/streamspace-templates/blob/master/CONTRIBUTING.md).
+To add your own templates, see the [Template Development Guide](https://github.com/JoshuaAFerguson/streamspace-templates/blob/main/CONTRIBUTING.md).

--- a/site/docs.html
+++ b/site/docs.html
@@ -70,7 +70,7 @@
         <li>Handles state transitions and hibernation</li>
         <li>Exports Prometheus metrics</li>
       </ul>
-      <p><a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/docs/ARCHITECTURE.md">View detailed architecture →</a></p>
+      <p><a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/docs/ARCHITECTURE.md">View detailed architecture →</a></p>
 
       <h3>2. API Backend</h3>
       <p>Go-based REST + WebSocket API using Gin framework.</p>
@@ -82,7 +82,7 @@
         <li>Connection tracking</li>
         <li>Real-time WebSocket updates</li>
       </ul>
-      <p><a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/api/README.md">API Backend documentation →</a></p>
+      <p><a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/api/README.md">API Backend documentation →</a></p>
 
       <h3>3. Web UI</h3>
       <p>React + TypeScript web interface with Material-UI.</p>
@@ -93,7 +93,7 @@
         <li>Admin panel for users, groups, quotas</li>
         <li>Real-time updates via WebSocket</li>
       </ul>
-      <p><a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/ui/README.md">UI documentation →</a></p>
+      <p><a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/ui/README.md">UI documentation →</a></p>
 
       <h2 id="installation">Installation</h2>
       <p>See the <a href="getting-started.html">Getting Started guide</a> for detailed installation instructions.</p>
@@ -212,7 +212,7 @@ kubectl delete session user1-firefox -n streamspace</code></pre>
         <li><code>GET /api/v1/plugins/installed</code> - List installed plugins</li>
       </ul>
 
-      <p><a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/api/README.md">Full API documentation →</a></p>
+      <p><a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/api/README.md">Full API documentation →</a></p>
 
       <h2 id="development">Development</h2>
 
@@ -234,7 +234,7 @@ make test
 make docker-build IMG=myregistry/streamspace-controller:dev</code></pre>
       </div>
 
-      <p><a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/controller/README.md">Controller development guide →</a></p>
+      <p><a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/controller/README.md">Controller development guide →</a></p>
 
       <h3>API Development</h3>
       <div class="code-block">
@@ -349,12 +349,12 @@ monitoring:
 
       <h3>Further Reading</h3>
       <ul>
-        <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/QUICKSTART.md">Quick Start Guide</a> - Get up and running in 10 minutes</li>
-        <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/FEATURES.md">Complete Feature List</a> - All implemented features</li>
-        <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/ROADMAP.md">Project Roadmap</a> - Phases 1-5 complete, Phase 6 planned</li>
-        <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/CLAUDE.md">AI Assistant Guide</a></li>
-        <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/CONTRIBUTING.md">Contributing Guide</a></li>
-        <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/docs/ARCHITECTURE.md">Architecture Deep Dive</a></li>
+        <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/QUICKSTART.md">Quick Start Guide</a> - Get up and running in 10 minutes</li>
+        <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/FEATURES.md">Complete Feature List</a> - All implemented features</li>
+        <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/ROADMAP.md">Project Roadmap</a> - Phases 1-5 complete, Phase 6 planned</li>
+        <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/CLAUDE.md">AI Assistant Guide</a></li>
+        <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/CONTRIBUTING.md">Contributing Guide</a></li>
+        <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/docs/ARCHITECTURE.md">Architecture Deep Dive</a></li>
         <li><a href="plugins.html">Plugin Development Guide</a></li>
       </ul>
 
@@ -384,8 +384,8 @@ monitoring:
         <h3>Resources</h3>
         <ul>
           <li><a href="features.html">Features</a></li>
-          <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/ROADMAP.md">Roadmap</a></li>
-          <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/CONTRIBUTING.md">Contributing</a></li>
+          <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/ROADMAP.md">Roadmap</a></li>
+          <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/CONTRIBUTING.md">Contributing</a></li>
           <li><a href="https://github.com/JoshuaAFerguson/streamspace/issues">Issues</a></li>
         </ul>
       </div>

--- a/site/features.html
+++ b/site/features.html
@@ -368,8 +368,8 @@
         <h3>Resources</h3>
         <ul>
           <li><a href="features.html">Features</a></li>
-          <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/ROADMAP.md">Roadmap</a></li>
-          <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/CONTRIBUTING.md">Contributing</a></li>
+          <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/ROADMAP.md">Roadmap</a></li>
+          <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/CONTRIBUTING.md">Contributing</a></li>
           <li><a href="https://github.com/JoshuaAFerguson/streamspace/issues">Issues</a></li>
         </ul>
       </div>

--- a/site/getting-started.html
+++ b/site/getting-started.html
@@ -232,8 +232,8 @@ kubectl get session my-firefox -n streamspace -o jsonpath='{.status.url}'</code>
         <li><a href="docs.html">Read the full documentation</a></li>
         <li><a href="features.html">Explore all features</a></li>
         <li><a href="plugins.html">Learn about the plugin system</a></li>
-        <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/ROADMAP.md">Check the roadmap</a></li>
-        <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/CONTRIBUTING.md">Contribute to the project</a></li>
+        <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/ROADMAP.md">Check the roadmap</a></li>
+        <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/CONTRIBUTING.md">Contribute to the project</a></li>
       </ul>
 
       <h3>Add Template Repositories</h3>
@@ -291,8 +291,8 @@ EOF</code></pre>
         <h3>Resources</h3>
         <ul>
           <li><a href="features.html">Features</a></li>
-          <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/ROADMAP.md">Roadmap</a></li>
-          <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/CONTRIBUTING.md">Contributing</a></li>
+          <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/ROADMAP.md">Roadmap</a></li>
+          <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/CONTRIBUTING.md">Contributing</a></li>
           <li><a href="https://github.com/JoshuaAFerguson/streamspace/issues">Issues</a></li>
         </ul>
       </div>

--- a/site/index.html
+++ b/site/index.html
@@ -207,8 +207,8 @@ kubectl port-forward -n streamspace svc/streamspace-ui 3000:80
         <h3>Resources</h3>
         <ul>
           <li><a href="features.html">Features</a></li>
-          <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/ROADMAP.md">Roadmap</a></li>
-          <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/CONTRIBUTING.md">Contributing</a></li>
+          <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/ROADMAP.md">Roadmap</a></li>
+          <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/CONTRIBUTING.md">Contributing</a></li>
           <li><a href="https://github.com/JoshuaAFerguson/streamspace/issues">Issues</a></li>
         </ul>
       </div>

--- a/site/plugins.html
+++ b/site/plugins.html
@@ -34,8 +34,8 @@
       <h1>Plugin System</h1>
       <p>Extend StreamSpace without modifying core code</p>
       <div class="hero-buttons mt-4">
-        <a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/PLUGIN_DEVELOPMENT.md" class="button button-primary">Developer Guide</a>
-        <a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/docs/PLUGIN_API.md" class="button button-secondary">API Reference</a>
+        <a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/PLUGIN_DEVELOPMENT.md" class="button button-primary">Developer Guide</a>
+        <a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/docs/PLUGIN_API.md" class="button button-secondary">API Reference</a>
       </div>
     </div>
   </section>
@@ -256,8 +256,8 @@ onUserLogout(user)           // User logs out</code></pre>
       <h2>Ready to Build a Plugin?</h2>
       <p class="mb-4">Comprehensive guides and API reference available</p>
       <div class="hero-buttons">
-        <a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/PLUGIN_DEVELOPMENT.md" class="button button-primary">Developer Guide (1,877 lines)</a>
-        <a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/docs/PLUGIN_API.md" class="button button-secondary">API Reference (1,569 lines)</a>
+        <a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/PLUGIN_DEVELOPMENT.md" class="button button-primary">Developer Guide (1,877 lines)</a>
+        <a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/docs/PLUGIN_API.md" class="button button-secondary">API Reference (1,569 lines)</a>
       </div>
     </div>
   </section>
@@ -281,8 +281,8 @@ onUserLogout(user)           // User logs out</code></pre>
         <h3>Resources</h3>
         <ul>
           <li><a href="features.html">Features</a></li>
-          <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/ROADMAP.md">Roadmap</a></li>
-          <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/CONTRIBUTING.md">Contributing</a></li>
+          <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/ROADMAP.md">Roadmap</a></li>
+          <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/CONTRIBUTING.md">Contributing</a></li>
           <li><a href="https://github.com/JoshuaAFerguson/streamspace/issues">Issues</a></li>
         </ul>
       </div>

--- a/site/templates.html
+++ b/site/templates.html
@@ -411,8 +411,8 @@ EOF</code></pre>
         <h3>Resources</h3>
         <ul>
           <li><a href="features.html">Features</a></li>
-          <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/ROADMAP.md">Roadmap</a></li>
-          <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/master/CONTRIBUTING.md">Contributing</a></li>
+          <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/ROADMAP.md">Roadmap</a></li>
+          <li><a href="https://github.com/JoshuaAFerguson/streamspace/blob/main/CONTRIBUTING.md">Contributing</a></li>
           <li><a href="https://github.com/JoshuaAFerguson/streamspace/issues">Issues</a></li>
         </ul>
       </div>

--- a/ui/public/.well-known/security.txt
+++ b/ui/public/.well-known/security.txt
@@ -23,16 +23,16 @@ Canonical: https://streamspace.local/.well-known/security.txt
 # We aim to respond within 48 hours and provide status updates within 7 days.
 #
 # For more information, see:
-# https://github.com/JoshuaAFerguson/streamspace/blob/master/SECURITY.md
+# https://github.com/JoshuaAFerguson/streamspace/blob/main/SECURITY.md
 
-Acknowledgments: https://github.com/JoshuaAFerguson/streamspace/blob/master/SECURITY.md#acknowledgments
+Acknowledgments: https://github.com/JoshuaAFerguson/streamspace/blob/main/SECURITY.md#acknowledgments
 
 # Encryption
 # Our PGP key for encrypted communications (optional - add when available)
 # Encryption: https://keys.openpgp.org/search?q=security@streamspace.io
 
 # Policy
-Policy: https://github.com/JoshuaAFerguson/streamspace/blob/master/SECURITY.md
+Policy: https://github.com/JoshuaAFerguson/streamspace/blob/main/SECURITY.md
 
 # Hiring
 # Interested in security work? Check our careers page


### PR DESCRIPTION
Update all repository branch references to reflect the new default branch name 'main'. This includes:

- GitHub Actions workflows (github-pages, image-signing, release, security-scan)
- Documentation files (CLAUDE.md, SECURITY_IMPL_GUIDE.md, SECURITY_TESTING.md)
- Website files (all HTML files in site/)
- Template documentation (manifests/templates/README.md)
- Security policy (ui/public/.well-known/security.txt)

External repository references (linuxserver, aquasecurity, golangci-lint, etc.) and Kubernetes node labels (node-role.kubernetes.io/master) remain unchanged as they reference external resources not under our control.