### PR TITLE
Fix GitHub Actions workflow failure

### DIFF
--- a/api/internal/plugins/database.go
+++ b/api/internal/plugins/database.go
@@ -186,7 +186,6 @@
 package plugins
 
 import (
-	"context"
 	"database/sql"
 	"fmt"
 

--- a/api/internal/plugins/logger.go
+++ b/api/internal/plugins/logger.go
@@ -61,7 +61,6 @@ package plugins
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
 	"time"
 )

--- a/api/internal/plugins/runtime.go
+++ b/api/internal/plugins/runtime.go
@@ -309,6 +309,10 @@ type LoadedPlugin struct {
 	// LoadedAt is the timestamp when the plugin was loaded into the runtime.
 	// Used for uptime monitoring and debugging load order issues.
 	LoadedAt time.Time
+
+	// IsBuiltin indicates whether the plugin is bundled with StreamSpace.
+	// Builtin plugins cannot be uninstalled and may have elevated permissions.
+	IsBuiltin bool
 }
 
 // PluginHandler is the interface that all plugins must implement.


### PR DESCRIPTION
- Add IsBuiltin field to LoadedPlugin struct
  - Fixes: runtime_v2.go:570: unknown field IsBuiltin error
  - Fixes: runtime_v2.go:581: undefined field IsBuiltin error
- Remove unused "context" import from database.go
- Remove unused "fmt" import from logger.go

These changes fix the GitHub Actions container build failure in the "Build & Sign API" job.