### PR TITLE
Fix multiple compilation errors in Go build

### DIFF
--- a/api/internal/auth/oidc.go
+++ b/api/internal/auth/oidc.go
@@ -267,7 +267,9 @@ func NewOIDCAuthenticator(config *OIDCConfig) (*OIDCAuthenticator, error) {
 		// For development only - skip TLS verification
 		client := &http.Client{
 			Transport: &http.Transport{
-				TLSClientConfig: &http.Transport{}.TLSClientConfig,
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
 			},
 		}
 		ctx = oidc.ClientContext(ctx, client)

--- a/api/internal/auth/saml.go
+++ b/api/internal/auth/saml.go
@@ -532,7 +532,7 @@ func NewSAMLAuthenticator(config *SAMLConfig) (*SAMLAuthenticator, error) {
 		Certificate:       sp.Certificate,        // Public certificate for IdP to verify
 		IDPMetadata:       sp.IDPMetadata,        // IdP configuration loaded above
 		AllowIDPInitiated: sp.AllowIDPInitiated,  // Security setting for unsolicited assertions
-		ForceAuthn:        sp.ForceAuthn,         // Whether to require re-authentication
+		ForceAuthn:        *sp.ForceAuthn,        // Whether to require re-authentication
 	})
 	if err != nil {
 		// Common causes:

--- a/api/internal/plugins/event_bus.go
+++ b/api/internal/plugins/event_bus.go
@@ -116,6 +116,7 @@
 package plugins
 
 import (
+	"fmt"
 	"log"
 	"sync"
 )

--- a/api/internal/plugins/runtime.go
+++ b/api/internal/plugins/runtime.go
@@ -706,7 +706,7 @@ func (r *Runtime) Stop(ctx context.Context) error {
 	defer r.pluginsMux.Unlock()
 
 	// Unload all plugins
-	for name, plugin := range r.plugins {
+	for name := range r.plugins {
 		if err := r.unloadPluginLocked(ctx, name); err != nil {
 			log.Printf("[Plugin Runtime] Error unloading plugin %s: %v", name, err)
 		}

--- a/api/internal/quota/enforcer.go
+++ b/api/internal/quota/enforcer.go
@@ -189,7 +189,7 @@ func NewEnforcer(userDB *db.UserDB, groupDB *db.GroupDB) *Enforcer {
 // It combines user-specific limits with group limits (taking the most restrictive)
 func (e *Enforcer) GetUserLimits(ctx context.Context, username string) (*Limits, error) {
 	// Get user from database
-	user, err := e.userDB.GetByUsername(ctx, username)
+	user, err := e.userDB.GetUserByUsername(ctx, username)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get user: %w", err)
 	}
@@ -233,7 +233,7 @@ func (e *Enforcer) GetUserLimits(ctx context.Context, username string) (*Limits,
 	// Check group limits and apply the most restrictive
 	if len(user.Groups) > 0 {
 		for _, groupName := range user.Groups {
-			group, err := e.groupDB.GetByName(ctx, groupName)
+			group, err := e.groupDB.GetGroupByName(ctx, groupName)
 			if err != nil {
 				continue // Skip groups that don't exist
 			}


### PR DESCRIPTION
Fixed compilation errors across the API codebase:

1. **go.mod**: Updated structured-merge-diff version to v6.3.0 to match go.sum
2. **quota/enforcer.go**: Fixed method calls (GetByUsername, GetGroupByName)
3. **auth/handlers.go**:
   - Fixed GetUserGroups return type handling
   - Added proper SAML assertion type handling
   - Fixed ExtractUserFromAssertion to handle 2 return values
   - Removed invalid Active field from CreateUserRequest
   - Updated to use UpdatePassword method
4. **auth/oidc.go**: Fixed TLSClientConfig initialization
5. **auth/saml.go**: Fixed ForceAuthn type mismatch (*bool to bool)
6. **plugins/event_bus.go**: Added missing fmt import
7. **plugins/runtime.go**: Removed unused plugin variable
8. **db/users.go**: Added missing methods:
   - GetUserByEmail
   - UpdatePassword
   - DB() accessor

All compilation errors have been resolved.