### PR TITLE
Fix GitHub Action build failures

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -23,6 +23,9 @@ RUN go mod download
 COPY cmd/ cmd/
 COPY internal/ internal/
 
+# Tidy modules to ensure go.mod and go.sum are up to date
+RUN go mod tidy
+
 # Build the API server with version info for the target architecture
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a \
     -ldflags "-w -s -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.buildDate=${BUILD_DATE}" \

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -22,6 +22,9 @@ COPY api/ api/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
 
+# Tidy modules to ensure go.mod and go.sum are up to date
+RUN go mod tidy
+
 # Build the controller with version info for the target architecture
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a \
     -ldflags "-w -s -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.buildDate=${BUILD_DATE}" \


### PR DESCRIPTION
Adds 'go mod tidy' step before the Go build command in both API and Controller Dockerfiles to ensure go.mod and go.sum are synchronized with the source code dependencies.

This fixes the GitHub Actions build failure:
"go: updates to go.mod needed; to update it: go mod tidy"

Changes:
- api/Dockerfile: Add go mod tidy step after copying source code
- controller/Dockerfile: Add go mod tidy step after copying source code

The cosign installation in GitHub Actions workflow already uses the official sigstore/cosign-installer@v3 action which properly supports Linux/amd64 and Linux/arm64 platforms.