### PR TITLE
Fix Go build errors in handlers

### DIFF
--- a/api/internal/handlers/console.go
+++ b/api/internal/handlers/console.go
@@ -86,13 +86,13 @@ type ConsoleSession struct {
 	ID             string                 `json:"id"`
 	SessionID      string                 `json:"session_id"`
 	UserID         string                 `json:"user_id"`
-	Type           string                 `json:"type"` // "terminal", "file_manager"
+	Type           string                 `json:"type"`   // "terminal", "file_manager"
 	Status         string                 `json:"status"` // "active", "idle", "disconnected"
 	WebSocketURL   string                 `json:"websocket_url,omitempty"`
 	CurrentPath    string                 `json:"current_path,omitempty"`
 	ShellType      string                 `json:"shell_type,omitempty"` // "bash", "sh", "zsh"
-	Columns        int                    `json:"columns,omitempty"` // Terminal columns
-	Rows           int                    `json:"rows,omitempty"` // Terminal rows
+	Columns        int                    `json:"columns,omitempty"`    // Terminal columns
+	Rows           int                    `json:"rows,omitempty"`       // Terminal rows
 	Metadata       map[string]interface{} `json:"metadata,omitempty"`
 	ConnectedAt    time.Time              `json:"connected_at"`
 	LastActivityAt time.Time              `json:"last_activity_at"`
@@ -101,25 +101,25 @@ type ConsoleSession struct {
 
 // FileInfo represents file/directory information
 type FileInfo struct {
-	Name         string    `json:"name"`
-	Path         string    `json:"path"`
-	Size         int64     `json:"size"`
-	IsDirectory  bool      `json:"is_directory"`
-	Permissions  string    `json:"permissions"`
-	Owner        string    `json:"owner"`
-	Group        string    `json:"group"`
-	ModifiedAt   time.Time `json:"modified_at"`
-	MimeType     string    `json:"mime_type,omitempty"`
-	SymlinkTarget string   `json:"symlink_target,omitempty"`
+	Name          string    `json:"name"`
+	Path          string    `json:"path"`
+	Size          int64     `json:"size"`
+	IsDirectory   bool      `json:"is_directory"`
+	Permissions   string    `json:"permissions"`
+	Owner         string    `json:"owner"`
+	Group         string    `json:"group"`
+	ModifiedAt    time.Time `json:"modified_at"`
+	MimeType      string    `json:"mime_type,omitempty"`
+	SymlinkTarget string    `json:"symlink_target,omitempty"`
 }
 
 // FileOperation represents a file operation result
 type FileOperation struct {
-	Operation string      `json:"operation"` // "create", "delete", "rename", "copy", "move", "upload", "download"
-	SourcePath string     `json:"source_path"`
-	TargetPath string     `json:"target_path,omitempty"`
-	Success   bool        `json:"success"`
-	Error     string      `json:"error,omitempty"`
+	Operation      string `json:"operation"` // "create", "delete", "rename", "copy", "move", "upload", "download"
+	SourcePath     string `json:"source_path"`
+	TargetPath     string `json:"target_path,omitempty"`
+	Success        bool   `json:"success"`
+	Error          string `json:"error,omitempty"`
 	BytesProcessed int64  `json:"bytes_processed,omitempty"`
 }
 
@@ -384,9 +384,9 @@ func (h *Handler) GetFileContent(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"path":    path,
-		"size":    info.Size(),
-		"content": string(content),
+		"path":     path,
+		"size":     info.Size(),
+		"content":  string(content),
 		"encoding": "utf-8",
 	})
 }
@@ -439,11 +439,11 @@ func (h *Handler) UploadFile(c *gin.Context) {
 	h.logFileOperation(sessionID, userID, "upload", filepath.Join(targetPath, header.Filename), "", bytesWritten)
 
 	c.JSON(http.StatusOK, gin.H{
-		"message":        "file uploaded successfully",
-		"filename":       header.Filename,
-		"size":           header.Size,
-		"bytes_written":  bytesWritten,
-		"path":           filepath.Join(targetPath, header.Filename),
+		"message":       "file uploaded successfully",
+		"filename":      header.Filename,
+		"size":          header.Size,
+		"bytes_written": bytesWritten,
+		"path":          filepath.Join(targetPath, header.Filename),
 	})
 }
 
@@ -646,24 +646,6 @@ func (h *Handler) RenameFile(c *gin.Context) {
 }
 
 // Helper functions
-
-func (h *Handler) canAccessSession(userID, sessionID string) bool {
-	var owner string
-	h.DB.QueryRow("SELECT user_id FROM sessions WHERE id = $1", sessionID).Scan(&owner)
-	if owner == userID {
-		return true
-	}
-
-	// Check shared access
-	var hasAccess bool
-	h.DB.QueryRow(`
-		SELECT EXISTS(
-			SELECT 1 FROM session_shares
-			WHERE session_id = $1 AND shared_with_user_id = $2
-		)
-	`, sessionID, userID).Scan(&hasAccess)
-	return hasAccess
-}
 
 func (h *Handler) getSessionBasePath(sessionID string) string {
 	// In production, this would return the actual path to the session's persistent volume

--- a/api/internal/handlers/sessiontemplates.go
+++ b/api/internal/handlers/sessiontemplates.go
@@ -1045,8 +1045,8 @@ func (h *SessionTemplatesHandler) canManageTemplate(ctx context.Context, templat
 
 // Template versioning implementations
 
-// TemplateVersion represents a version snapshot of a template
-type TemplateVersion struct {
+// TemplateSnapshot represents a version snapshot of a template
+type TemplateSnapshot struct {
 	ID            int                    `json:"id"`
 	TemplateID    string                 `json:"templateId"`
 	VersionNumber int                    `json:"versionNumber"`
@@ -1101,9 +1101,9 @@ func (h *SessionTemplatesHandler) ListTemplateVersions(c *gin.Context) {
 	}
 	defer rows.Close()
 
-	versions := []TemplateVersion{}
+	versions := []TemplateSnapshot{}
 	for rows.Next() {
-		var version TemplateVersion
+		var version TemplateSnapshot
 		var templateDataJSON []byte
 		var tagsArray sql.NullString
 


### PR DESCRIPTION
Fixed multiple compilation errors preventing the API build:

1. websocket/handlers.go:238 - Fixed unused 'err' variable by adding proper error handling with default value fallback

2. template_versioning.go & sessiontemplates.go - Resolved duplicate TemplateVersion type declaration by renaming sessiontemplates version to TemplateSnapshot (different purpose/structure)

3. console.go & collaboration.go - Removed duplicate canAccessSession method from console.go, enhanced the collaboration.go version to include shared access checking

4. collaboration.go - Fixed 27 instances of missing DB methods by changing h.DB.QueryRow() to h.DB.DB().QueryRow() and h.DB.Exec() to h.DB.DB().Exec() to properly access the underlying sql.DB instance

All files verified with syntax checking. API build should now succeed.