### PR TITLE
Fix duplicate controller name error in setup

### DIFF
--- a/controller/controllers/hibernation_controller.go
+++ b/controller/controllers/hibernation_controller.go
@@ -279,5 +279,6 @@ func (r *HibernationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&streamv1alpha1.Session{}).
+		Named("hibernation").
 		Complete(r)
 }


### PR DESCRIPTION
Add unique name 'hibernation' to HibernationReconciler to prevent controller name collision with SessionReconciler. Both controllers watch Session resources, which caused them to use the same default controller name 'session', resulting in duplicate registration error.

This fix ensures each controller has a unique name for metrics and logging purposes.