### PR TITLE
Fix reconnecting dialog refreshing page repeatedly

### DIFF
--- a/ui/src/components/EnhancedWebSocketStatus.tsx
+++ b/ui/src/components/EnhancedWebSocketStatus.tsx
@@ -60,16 +60,17 @@ export default function EnhancedWebSocketStatus({
   useEffect(() => {
     if (reconnectAttempts > 0 && !isConnected) {
       const delay = getReconnectDelay(reconnectAttempts - 1);
-      setCountdown(delay);
+      let remainingTime = delay;
+      setCountdown(remainingTime);
 
       const interval = setInterval(() => {
-        setCountdown((prev) => {
-          if (prev === null || prev <= 1) {
-            clearInterval(interval);
-            return null;
-          }
-          return prev - 1;
-        });
+        remainingTime -= 1;
+        if (remainingTime <= 0) {
+          clearInterval(interval);
+          setCountdown(null);
+        } else {
+          setCountdown(remainingTime);
+        }
       }, 1000);
 
       return () => clearInterval(interval);


### PR DESCRIPTION
Fixed critical issue where WebSocket reconnection logic created a rapid reconnection loop, making the UI appear to "refresh every second" and become completely unusable.

Changes:
- Fixed dependency loop in useWebSocket hook by using ref for reconnect attempts
- Removed reconnectAttempts from connect() callback dependencies
- Improved countdown timer in EnhancedWebSocketStatus to be more efficient
- Made reconnect banner dismissal persistent across reconnection attempts
- Reduced notification spam when banner is dismissed

Root cause: The connect() callback depended on reconnectAttempts state, which changed on every reconnection attempt. This triggered the useEffect to close and immediately reconnect, creating a loop.

Testing: Code review confirmed proper use of refs to break dependency cycle. The reconnection logic now only triggers on genuine WebSocket close events, not on state changes.