### PR TITLE
Review streamspace templates repository format

### DIFF
--- a/api/internal/sync/parser.go
+++ b/api/internal/sync/parser.go
@@ -25,7 +25,7 @@ import (
 //
 // Validation:
 //   - Required fields: name, displayName, baseImage
-//   - API version: stream.streamspace.io/v1alpha1
+//   - API version: stream.space/v1alpha1 (or stream.streamspace.io/v1alpha1 for backward compatibility)
 //   - App type inference: desktop (VNC) or webapp (HTTP)
 //
 // Example usage:
@@ -119,7 +119,7 @@ type ParsedTemplate struct {
 //
 // Example YAML:
 //
-//	apiVersion: stream.streamspace.io/v1alpha1
+//	apiVersion: stream.space/v1alpha1
 //	kind: Template
 //	metadata:
 //	  name: firefox-browser
@@ -293,8 +293,9 @@ func (p *TemplateParser) ParseTemplateFile(filePath string) (*ParsedTemplate, er
 		return nil, fmt.Errorf("not a Template resource (kind: %s)", manifest.Kind)
 	}
 
-	if manifest.APIVersion != "stream.streamspace.io/v1alpha1" {
-		return nil, fmt.Errorf("unsupported API version: %s", manifest.APIVersion)
+	// Support both old and new API versions for backward compatibility
+	if manifest.APIVersion != "stream.space/v1alpha1" && manifest.APIVersion != "stream.streamspace.io/v1alpha1" {
+		return nil, fmt.Errorf("unsupported API version: %s (expected stream.space/v1alpha1)", manifest.APIVersion)
 	}
 
 	// Validate required fields
@@ -406,8 +407,9 @@ func (p *TemplateParser) ValidateTemplateManifest(yamlContent string) error {
 		return fmt.Errorf("kind must be 'Template', got '%s'", manifest.Kind)
 	}
 
-	if manifest.APIVersion != "stream.streamspace.io/v1alpha1" {
-		return fmt.Errorf("apiVersion must be 'stream.streamspace.io/v1alpha1', got '%s'", manifest.APIVersion)
+	// Support both old and new API versions
+	if manifest.APIVersion != "stream.space/v1alpha1" && manifest.APIVersion != "stream.streamspace.io/v1alpha1" {
+		return fmt.Errorf("apiVersion must be 'stream.space/v1alpha1', got '%s'", manifest.APIVersion)
 	}
 
 	if manifest.Metadata.Name == "" {


### PR DESCRIPTION
…ibility

This commit ensures the StreamSpace application can properly read and sync the official streamspace-templates repository.

Changes:
1. Fixed parser API version validation
   - Changed from stream.streamspace.io/v1alpha1 to stream.space/v1alpha1
   - Added backward compatibility for old API version
   - Updated documentation to reflect correct API group

2. Added default repository initialization
   - Hardcoded streamspace-templates repository URL
   - Automatically inserts default repository on database migration
   - Repository will be synced automatically by sync service on startup
   - URL: https://github.com/JoshuaAFerguson/streamspace-templates
   - Branch: main
   - Auth: none (public repository)

Benefits:
- Users get 195+ templates out of the box
- No manual configuration required
- Repository sync happens automatically
- Fixes API version mismatch between parser and CRD definition

Files modified:
- api/internal/sync/parser.go: Updated API version validation
- api/internal/db/database.go: Added ensureDefaultRepository() function