### PR TITLE
Set up default plugin repository

### DIFF
--- a/api/internal/db/database.go
+++ b/api/internal/db/database.go
@@ -378,6 +378,12 @@ func (d *Database) Migrate() error {
 			updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 		)`,
 
+		// Insert default repositories (plugins and templates)
+		`INSERT INTO repositories (name, url, branch, auth_type, status) VALUES
+			('Official Plugins', 'https://github.com/JoshuaAFerguson/streamspace-plugins', 'main', 'none', 'active'),
+			('Official Templates', 'https://github.com/JoshuaAFerguson/streamspace-templates', 'main', 'none', 'active')
+		ON CONFLICT (name) DO NOTHING`,
+
 		// Catalog templates (cache of templates from repos)
 		`CREATE TABLE IF NOT EXISTS catalog_templates (
 			id SERIAL PRIMARY KEY,


### PR DESCRIPTION
Add hardcoded default repositories to database initialization:
- Official Plugins: https://github.com/JoshuaAFerguson/streamspace-plugins
- Official Templates: https://github.com/JoshuaAFerguson/streamspace-templates

This ensures that the StreamSpace platform has default repositories configured on first initialization, allowing users to immediately access the official plugin and template catalogs without manual configuration.

The INSERT uses ON CONFLICT DO NOTHING for idempotency, so it won't fail on subsequent database initializations.