### PR TITLE
Fix user and group creation functionality

### DIFF
--- a/api/internal/db/database.go
+++ b/api/internal/db/database.go
@@ -527,11 +527,12 @@ func (d *Database) Migrate() error {
 		// Insert default all_users group that all users belong to
 		`INSERT INTO groups (id, name, display_name, description, type)
 		VALUES ('all-users', 'all_users', 'All Users', 'Default group containing all users', 'system')
-		ON CONFLICT (id) DO NOTHING`,
+		ON CONFLICT (name) DO NOTHING`,
 
 		// Add admin user to all_users group
 		`INSERT INTO group_memberships (id, user_id, group_id, role, created_at)
-		VALUES ('admin-all-users', 'admin', 'all-users', 'member', NOW())
+		SELECT 'admin-all-users', 'admin', id, 'member', NOW()
+		FROM groups WHERE name = 'all_users'
 		ON CONFLICT (user_id, group_id) DO NOTHING`,
 
 		// Insert default configuration values


### PR DESCRIPTION
- Change ON CONFLICT clause from (id) to (name) for all_users group insert to properly handle cases where a group with the same name but different id already exists
- Update admin group membership insert to use subquery instead of hardcoded group_id, making it work regardless of the all_users group's actual id