### PR TITLE
Fix undefined sql package in handlers

### DIFF
--- a/api/internal/api/handlers.go
+++ b/api/internal/api/handlers.go
@@ -94,6 +94,7 @@ package api
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"log"
 	"net/http"


### PR DESCRIPTION
The handlers.go file uses sql.NullTime and sql.NullString for repository listing but was missing the database/sql import, causing build failures.