### PR TITLE
Fix template listing permissions for service account

### DIFF
--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -9,13 +9,13 @@ metadata:
     {{- include "streamspace.controller.labels" . | nindent 4 }}
 rules:
   # Sessions and Templates CRDs
-  - apiGroups: ["stream.streamspace.io"]
+  - apiGroups: ["stream.space"]
     resources: ["sessions", "templates"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: ["stream.streamspace.io"]
+  - apiGroups: ["stream.space"]
     resources: ["sessions/status", "templates/status"]
     verbs: ["get", "update", "patch"]
-  - apiGroups: ["stream.streamspace.io"]
+  - apiGroups: ["stream.space"]
     resources: ["sessions/finalizers", "templates/finalizers"]
     verbs: ["update"]
   
@@ -68,13 +68,13 @@ metadata:
     {{- include "streamspace.api.labels" . | nindent 4 }}
 rules:
   # Sessions and Templates CRDs
-  - apiGroups: ["stream.streamspace.io"]
+  - apiGroups: ["stream.space"]
     resources: ["sessions", "templates"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: ["stream.streamspace.io"]
+  - apiGroups: ["stream.space"]
     resources: ["sessions/status", "templates/status"]
     verbs: ["get", "update", "patch"]
-  
+
   # Pods for logs streaming
   - apiGroups: [""]
     resources: ["pods", "pods/log"]

--- a/manifests/kubectl/rbac.yaml
+++ b/manifests/kubectl/rbac.yaml
@@ -26,34 +26,34 @@ metadata:
     app.kubernetes.io/component: controller
 rules:
   # Session resources
-  - apiGroups: ["stream.streamspace.io"]
+  - apiGroups: ["stream.space"]
     resources: ["sessions"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: ["stream.streamspace.io"]
+  - apiGroups: ["stream.space"]
     resources: ["sessions/status"]
     verbs: ["get", "update", "patch"]
-  - apiGroups: ["stream.streamspace.io"]
+  - apiGroups: ["stream.space"]
     resources: ["sessions/finalizers"]
     verbs: ["update"]
 
   # Template resources
-  - apiGroups: ["stream.streamspace.io"]
+  - apiGroups: ["stream.space"]
     resources: ["templates"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: ["stream.streamspace.io"]
+  - apiGroups: ["stream.space"]
     resources: ["templates/status"]
     verbs: ["get"]
 
   # TemplateRepository resources
-  - apiGroups: ["stream.streamspace.io"]
+  - apiGroups: ["stream.space"]
     resources: ["templaterepositories"]
     verbs: ["get", "list", "watch"]
 
   # Connection resources
-  - apiGroups: ["stream.streamspace.io"]
+  - apiGroups: ["stream.space"]
     resources: ["connections"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: ["stream.streamspace.io"]
+  - apiGroups: ["stream.space"]
     resources: ["connections/status"]
     verbs: ["get", "update", "patch"]
 
@@ -160,10 +160,10 @@ metadata:
     app.kubernetes.io/component: api
 rules:
   # Read-only access to CRDs
-  - apiGroups: ["stream.streamspace.io"]
+  - apiGroups: ["stream.space"]
     resources: ["sessions", "templates", "templaterepositories", "connections"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: ["stream.streamspace.io"]
+  - apiGroups: ["stream.space"]
     resources: ["sessions/status", "templates/status", "connections/status"]
     verbs: ["get"]
 


### PR DESCRIPTION
The RBAC rules were using the incorrect API group 'stream.streamspace.io' instead of 'stream.space' which the CRDs actually use. This caused the API service account to fail when listing templates with a forbidden error.