### PR TITLE
Fix plugin catalog array parsing error

### DIFF
--- a/api/internal/sync/sync.go
+++ b/api/internal/sync/sync.go
@@ -39,6 +39,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/lib/pq"
 	"github.com/streamspace/streamspace/api/internal/db"
 )
 
@@ -401,12 +402,6 @@ func (s *SyncService) updateCatalog(ctx context.Context, repoID int, templates [
 		// Convert manifest to JSON string for storage
 		manifestJSON := template.Manifest
 
-		// Convert tags slice to JSON for database storage
-		tagsJSON, err := json.Marshal(template.Tags)
-		if err != nil {
-			return fmt.Errorf("failed to marshal tags for template %s: %w", template.Name, err)
-		}
-
 		_, err = tx.ExecContext(ctx, `
 			INSERT INTO catalog_templates (
 				repository_id, name, display_name, description, category,
@@ -414,7 +409,7 @@ func (s *SyncService) updateCatalog(ctx context.Context, repoID int, templates [
 			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 		`, repoID, template.Name, template.DisplayName, template.Description,
 			template.Category, template.AppType, template.Icon, manifestJSON,
-			string(tagsJSON), time.Now(), time.Now())
+			pq.Array(template.Tags), time.Now(), time.Now())
 
 		if err != nil {
 			return fmt.Errorf("failed to insert template %s: %w", template.Name, err)
@@ -449,12 +444,6 @@ func (s *SyncService) updatePluginCatalog(ctx context.Context, repoID int, plugi
 
 	// Insert new plugins
 	for _, plugin := range plugins {
-		// Convert tags slice to JSON for database storage
-		tagsJSON, err := json.Marshal(plugin.Tags)
-		if err != nil {
-			return fmt.Errorf("failed to marshal tags for plugin %s: %w", plugin.Name, err)
-		}
-
 		_, err = tx.ExecContext(ctx, `
 			INSERT INTO catalog_plugins (
 				repository_id, name, version, display_name, description, category,
@@ -462,7 +451,7 @@ func (s *SyncService) updatePluginCatalog(ctx context.Context, repoID int, plugi
 			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 		`, repoID, plugin.Name, plugin.Version, plugin.DisplayName, plugin.Description,
 			plugin.Category, plugin.PluginType, plugin.Icon, plugin.Manifest,
-			string(tagsJSON), time.Now(), time.Now())
+			pq.Array(plugin.Tags), time.Now(), time.Now())
 
 		if err != nil {
 			return fmt.Errorf("failed to insert plugin %s: %w", plugin.Name, err)


### PR DESCRIPTION
Replace json.Marshal() with pq.Array() for tags field when inserting plugins and templates into catalog tables. JSON format ["tag1","tag2"] is not valid for PostgreSQL TEXT[] columns - they require {"tag1","tag2"} format which pq.Array() provides.

This fixes the "malformed array literal" errors during catalog sync.