### PR TITLE
Remove unused JSON import from sync package

### DIFF
--- a/api/internal/sync/sync.go
+++ b/api/internal/sync/sync.go
@@ -32,7 +32,6 @@ package sync
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"


### PR DESCRIPTION
Remove unused import that was causing build failure in the API server Docker build.