### PR TITLE
Fix duplicate template catalog insertion error

### DIFF
--- a/api/internal/handlers/plugins.go
+++ b/api/internal/handlers/plugins.go
@@ -357,7 +357,7 @@ func (h *PluginHandler) BrowsePluginCatalog(c *gin.Context) {
 			cp.created_at, cp.updated_at,
 			r.id as repo_id, r.name as repo_name, r.url as repo_url, r.type as repo_type
 		FROM catalog_plugins cp
-		JOIN catalog_repositories r ON cp.repository_id = r.id
+		JOIN repositories r ON cp.repository_id = r.id
 		WHERE 1=1
 	`
 
@@ -502,7 +502,7 @@ func (h *PluginHandler) GetCatalogPlugin(c *gin.Context) {
 			cp.created_at, cp.updated_at,
 			r.id as repo_id, r.name as repo_name, r.url as repo_url, r.type as repo_type
 		FROM catalog_plugins cp
-		JOIN catalog_repositories r ON cp.repository_id = r.id
+		JOIN repositories r ON cp.repository_id = r.id
 		WHERE cp.id = $1
 	`
 


### PR DESCRIPTION
- Deduplicate templates by name before inserting to prevent unique constraint violations when repository has duplicate template names
- Fix table name mismatch: change catalog_repositories to repositories in sync.go UPDATE query and plugins.go JOIN queries
- This fixes the "duplicate key value violates unique constraint" error for blender template and resolves empty plugin catalog results