### PR TITLE
fix: add missing InstallStatus and InstallMessage fields to Installed…

### DIFF
--- a/api/internal/db/applications.go
+++ b/api/internal/db/applications.go
@@ -167,7 +167,9 @@ func (a *ApplicationDB) GetApplication(ctx context.Context, appID string) (*mode
 			COALESCE(ct.name, '') as template_name, COALESCE(ct.display_name, ia.display_name) as template_display_name,
 			COALESCE(ct.description, '') as description, COALESCE(ct.category, '') as category,
 			COALESCE(ct.app_type, '') as app_type, COALESCE(ct.icon_url, '') as icon_url,
-			COALESCE(ct.manifest, '') as manifest
+			COALESCE(ct.manifest, '') as manifest,
+			COALESCE(ia.install_status, '') as install_status,
+			COALESCE(ia.install_message, '') as install_message
 		FROM installed_applications ia
 		LEFT JOIN catalog_templates ct ON ia.catalog_template_id = ct.id
 		WHERE ia.id = $1
@@ -178,6 +180,7 @@ func (a *ApplicationDB) GetApplication(ctx context.Context, appID string) (*mode
 		&app.Enabled, &configJSON, &app.CreatedBy, &app.CreatedAt, &app.UpdatedAt,
 		&app.TemplateName, &app.TemplateDisplayName, &app.Description,
 		&app.Category, &app.AppType, &app.IconURL, &app.Manifest,
+		&app.InstallStatus, &app.InstallMessage,
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -207,7 +210,9 @@ func (a *ApplicationDB) ListApplications(ctx context.Context, enabledOnly bool) 
 			ia.enabled, ia.configuration, ia.created_by, ia.created_at, ia.updated_at,
 			COALESCE(ct.name, '') as template_name, COALESCE(ct.display_name, ia.display_name) as template_display_name,
 			COALESCE(ct.description, '') as description, COALESCE(ct.category, '') as category,
-			COALESCE(ct.app_type, '') as app_type, COALESCE(ct.icon_url, '') as icon_url
+			COALESCE(ct.app_type, '') as app_type, COALESCE(ct.icon_url, '') as icon_url,
+			COALESCE(ia.install_status, '') as install_status,
+			COALESCE(ia.install_message, '') as install_message
 		FROM installed_applications ia
 		LEFT JOIN catalog_templates ct ON ia.catalog_template_id = ct.id
 		WHERE 1=1
@@ -242,6 +247,7 @@ func (a *ApplicationDB) ListApplications(ctx context.Context, enabledOnly bool) 
 			&app.Enabled, &configJSON, &app.CreatedBy, &app.CreatedAt, &app.UpdatedAt,
 			&app.TemplateName, &app.TemplateDisplayName, &app.Description,
 			&app.Category, &app.AppType, &app.IconURL,
+			&app.InstallStatus, &app.InstallMessage,
 		)
 		if err != nil {
 			fmt.Printf("Error scanning application row: %v\n", err)
@@ -458,7 +464,9 @@ func (a *ApplicationDB) GetUserAccessibleApplications(ctx context.Context, userI
 			ia.enabled, ia.configuration, ia.created_by, ia.created_at, ia.updated_at,
 			COALESCE(ct.name, '') as template_name, COALESCE(ct.display_name, ia.display_name) as template_display_name,
 			COALESCE(ct.description, '') as description, COALESCE(ct.category, '') as category,
-			COALESCE(ct.app_type, '') as app_type, COALESCE(ct.icon_url, '') as icon_url
+			COALESCE(ct.app_type, '') as app_type, COALESCE(ct.icon_url, '') as icon_url,
+			COALESCE(ia.install_status, '') as install_status,
+			COALESCE(ia.install_message, '') as install_message
 		FROM installed_applications ia
 		LEFT JOIN catalog_templates ct ON ia.catalog_template_id = ct.id
 		WHERE ia.enabled = true
@@ -494,6 +502,7 @@ func (a *ApplicationDB) GetUserAccessibleApplications(ctx context.Context, userI
 			&app.Enabled, &configJSON, &app.CreatedBy, &app.CreatedAt, &app.UpdatedAt,
 			&app.TemplateName, &app.TemplateDisplayName, &app.Description,
 			&app.Category, &app.AppType, &app.IconURL,
+			&app.InstallStatus, &app.InstallMessage,
 		)
 		if err != nil {
 			fmt.Printf("Error scanning application row: %v\n", err)

--- a/api/internal/models/application.go
+++ b/api/internal/models/application.go
@@ -77,6 +77,12 @@ type InstalledApplication struct {
 	IconURL             string `json:"icon,omitempty"`
 	Manifest            string `json:"manifest,omitempty"`
 
+	// InstallStatus tracks the installation state (pending, creating, installed, failed)
+	InstallStatus string `json:"installStatus,omitempty" db:"install_status"`
+
+	// InstallMessage provides additional context about the installation status
+	InstallMessage string `json:"installMessage,omitempty" db:"install_message"`
+
 	// Groups with access to this application (populated separately)
 	Groups []*ApplicationGroupAccess `json:"groups,omitempty"`
 }


### PR DESCRIPTION
…Application model

The applications.go handler was referencing InstallStatus and InstallMessage fields that did not exist on the InstalledApplication struct, causing Docker build failures.

Changes:
- Add InstallStatus and InstallMessage fields to InstalledApplication model
- Update GetApplication query to select install_status and install_message
- Update ListApplications query to include these fields
- Update GetUserAccessibleApplications query to include these fields