### PR TITLE
fix(ci): bump GO_VERSION to 1.25 + golangci-lint v2.5 + repair sha tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,8 @@ jobs:
         run: |
           go fmt ./...
           go vet ./...
-          # Install golangci-lint
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
+          # Install golangci-lint (pinned to a version that supports the modules' Go directive)
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" "${GOLANGCI_LINT_VERSION}"
           golangci-lint run
 
       - name: Download API dependencies

--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -65,7 +65,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=sha,prefix={{branch}}-
+            type=sha,prefix=sha-
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set build variables
@@ -234,7 +234,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=sha,prefix={{branch}}-
+            type=sha,prefix=sha-
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set build variables
@@ -403,7 +403,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=sha,prefix={{branch}}-
+            type=sha,prefix=sha-
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set build variables

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - name: Download dependencies
         run: |


### PR DESCRIPTION
## Summary

Repairs three pre-existing CI failures unrelated to product code:

1. **\`GO_VERSION: '1.21'\`** was older than every module in the repo (api: 1.24, k8s-agent: 1.24, docker-agent: 1.25). Lint and build steps could not parse the modules' Go directive. Bumped to 1.25 across \`ci.yml\`; aligned \`security-scan.yml\` 1.24 → 1.25.

2. **\`golangci-lint v1.55.2\`** cannot read Go 1.23+ export data — the K8s agent lint failed with \`internal/goarch unsupported version: 2\`. Pinned to \`v2.5.0\` via \`GOLANGCI_LINT_VERSION\` env var.

3. **Bad image tag template** — \`container-images.yml\` had \`type=sha,prefix={{branch}}-\` at three lines. \`{{branch}}\` evaluates to empty on \`pull_request\` events, so buildx received \`:-<sha>\` and aborted with \`invalid reference format\`. Replaced with \`prefix=sha-\` for an always-valid tag.

## Files

- \`.github/workflows/ci.yml\` — env var bump + golangci-lint pin
- \`.github/workflows/container-images.yml\` — sha tag prefix fix (×3)
- \`.github/workflows/security-scan.yml\` — go-version 1.24 → 1.25

## Test plan

- [ ] CI passes (Lint, Test, Build & Sign jobs all green for the first time in 5+ months)