### PR TITLE
fix(websocket): repair race in TestUpdateAgentHeartbeat

### DIFF
--- a/api/internal/websocket/agent_hub_test.go
+++ b/api/internal/websocket/agent_hub_test.go
@@ -226,7 +226,22 @@ func TestUpdateAgentHeartbeat(t *testing.T) {
 		t.Fatalf("Failed to register agent: %v", err)
 	}
 
-	time.Sleep(100 * time.Millisecond)
+	// Wait for the registration UPDATE to be consumed by the Run() goroutine
+	// before declaring the next expectation. Calling mock.ExpectExec while
+	// the registration goroutine is still inside sqlmock.exec races on
+	// sqlmock's internal expected[] slice (go-sqlmock <=1.5.2 is not safe
+	// for concurrent ExpectExec/exec).
+	deadline := time.After(2 * time.Second)
+	for {
+		if mock.ExpectationsWereMet() == nil {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timeout waiting for registration UPDATE to be consumed")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
 
 	// Mock database update for heartbeat (includes status update)
 	// Note: Query uses $1 for both last_heartbeat and updated_at, so only 2 args (timestamp, agentID)


### PR DESCRIPTION
## Summary

\`Run()\` executes in a goroutine and calls \`handleRegister\`, which fires a sqlmock-backed \`Exec\` for the registration \`UPDATE\`. The test then calls \`mock.ExpectExec\` to declare the heartbeat expectation. \`go-sqlmock <=1.5.2\` doesn't synchronize \`ExpectExec\` writes against \`exec\` reads on its internal \`expected[]\` slice — the original \`time.Sleep(100ms)\` was a guess and not always enough, so \`-race\` flagged it intermittently.

\`\`\`
WARNING: DATA RACE
Write at … by goroutine 23:
  go-sqlmock.(*sqlmock).ExpectExec()
  …websocket.TestUpdateAgentHeartbeat() agent_hub_test.go:233

Previous read at … by goroutine 25:
  go-sqlmock.(*sqlmock).exec()
  …websocket.(*AgentHub).handleRegister() agent_hub.go:265
  …websocket.(*AgentHub).Run() agent_hub.go:216
\`\`\`

## Fix

Replace the sleep with a deadline poll on \`mock.ExpectationsWereMet()\`. The poll only completes after the registration \`UPDATE\` has been consumed, so the subsequent \`ExpectExec\` runs without a concurrent reader.

## Verified

\`go test -race -count=20\` → 20/20 clean (was failing intermittently before; CI race had been failing for 5+ months).

## Test plan

- [x] \`go test -race -run TestUpdateAgentHeartbeat -count=20\` clean locally
- [x] Full \`go test -race ./internal/websocket/\` passes
- [ ] CI green (after PR #255 lands so the lint/build infra works)