### PR TITLE
fix: race in TestProcessCommandAgentConnected + 6 lint issues

### DIFF
--- a/agents/k8s-agent/agent_vnc_tunnel.go
+++ b/agents/k8s-agent/agent_vnc_tunnel.go
@@ -176,7 +176,7 @@ func (m *VNCTunnelManager) CloseTunnel(sessionID string) error {
 
 	// Close connection
 	if tunnel.conn != nil {
-		tunnel.conn.Close()
+		_ = tunnel.conn.Close()
 	}
 
 	log.Printf("[VNCTunnel] Tunnel closed for session %s", sessionID)

--- a/agents/k8s-agent/internal/errors/errors.go
+++ b/agents/k8s-agent/internal/errors/errors.go
@@ -25,7 +25,7 @@ var (
 	ErrCommandFailed     = stderrors.New("command execution failed")
 	ErrSessionNotFound   = stderrors.New("session not found")
 	ErrTemplateNotFound  = stderrors.New("template not found")
-	ErrResourceNotFound  = stderrors.New("Kubernetes resource not found")
+	ErrResourceNotFound  = stderrors.New("kubernetes resource not found")
 )
 
 // Kubernetes errors

--- a/agents/k8s-agent/main.go
+++ b/agents/k8s-agent/main.go
@@ -235,7 +235,7 @@ func (a *K8sAgent) shutdown() {
 
 	if a.wsConn != nil {
 		// Close connection (writePump already stopped, safe to close directly)
-		a.wsConn.Close()
+		_ = a.wsConn.Close()
 		a.wsConn = nil
 	}
 
@@ -533,7 +533,7 @@ func (a *K8sAgent) registerAgent() error {
 	if err != nil {
 		return fmt.Errorf("HTTP request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// Check response status
 	// ISSUE #234: Accept 202 Accepted for pending approval workflow
@@ -580,11 +580,11 @@ func (a *K8sAgent) registerAgent() error {
 				// Check if still pending
 				var retryRegResp AgentRegistrationResponse
 				if err := json.NewDecoder(retryResp.Body).Decode(&retryRegResp); err != nil {
-					retryResp.Body.Close()
+					_ = retryResp.Body.Close()
 					log.Printf("[K8sAgent] Failed to decode retry response: %v. Continuing to wait...", err)
 					continue
 				}
-				retryResp.Body.Close()
+				_ = retryResp.Body.Close()
 
 				// Check approval status
 				if retryRegResp.ApprovalStatus == "pending" {

--- a/api/internal/services/command_dispatcher_test.go
+++ b/api/internal/services/command_dispatcher_test.go
@@ -216,7 +216,20 @@ func TestProcessCommandAgentConnected(t *testing.T) {
 		t.Fatalf("Failed to register agent: %v", err)
 	}
 
-	time.Sleep(100 * time.Millisecond)
+	// Wait for the registration UPDATE to drain through the Run() goroutine
+	// before declaring the next expectation. See agent_hub_test.go for the
+	// underlying go-sqlmock <=1.5.2 race rationale.
+	deadline := time.After(2 * time.Second)
+	for {
+		if mock.ExpectationsWereMet() == nil {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timeout waiting for registration UPDATE to be consumed")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
 
 	// Start dispatcher
 	go dispatcher.Start()


### PR DESCRIPTION
## Summary

Two pre-existing CI failures newly visible after PR #255 / #256 made the lint and test infrastructure functional:

### 1. Second sqlmock race

\`TestProcessCommandAgentConnected\` raced on go-sqlmock for the same reason \`TestUpdateAgentHeartbeat\` did (PR #256) — \`go hub.Run()\` goroutine inside \`sqlmock.exec\` while the test goroutine calls \`mock.ExpectExec\`. Apply the same \`ExpectationsWereMet\` polling pattern.

### 2. golangci-lint v2.5 findings (newly running)

| File | Issue | Fix |
|---|---|---|
| \`agent_vnc_tunnel.go:179\` | unchecked \`tunnel.conn.Close()\` | \`_ = tunnel.conn.Close()\` |
| \`main.go:238\` | unchecked \`a.wsConn.Close()\` | \`_ = a.wsConn.Close()\` |
| \`main.go:536\` | unchecked deferred \`resp.Body.Close()\` | \`defer func() { _ = ... }()\` |
| \`main.go:583,587\` | unchecked \`retryResp.Body.Close()\` (×2) | \`_ = retryResp.Body.Close()\` |
| \`internal/errors/errors.go:28\` | ST1005 capitalized \"Kubernetes resource not found\" | lowercase to \"kubernetes…\" |

## Verified

- \`go test -race -run TestProcessCommandAgentConnected -count=10 ./internal/services/\` clean (10/10)
- \`go build ./...\` clean in both modules

## Deferred

Other test files (\`agent_hub_redis_test.go\`, \`websocket_enterprise_test.go\`, …) use the same \`time.Sleep\` + \`mock.ExpectExec\` pattern. They have not yet failed under \`-race\` in CI; defer until they do (or a sweep PR if there's appetite).