### PR TITLE
docs(README): warn that chrome-selkies image is not yet published

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,14 @@ For the deeper technical reference, see [`docs/ARCHITECTURE.md`](docs/ARCHITECTU
 
 ## Available applications
 
-Templates live in [`streamspace-templates`](https://github.com/streamspace-dev/streamspace-templates). The image-build pipeline in that repo publishes signed multi-arch images to `ghcr.io/streamspace-dev/<image>`. The current bootstrap image is:
+Templates live in [`streamspace-templates`](https://github.com/streamspace-dev/streamspace-templates). The image-build pipeline in that repo is set up to publish signed multi-arch images to `ghcr.io/streamspace-dev/<image>` with cosign signatures and SPDX SBOM attestations.
 
-- `ghcr.io/streamspace-dev/chrome-selkies` — Google Chrome streamed via Selkies-GStreamer
+> [!WARNING]
+> **No image is published yet.** The pipeline's first image source — `chrome-selkies` — references a base image (`ghcr.io/selkies-project/selkies-gstreamer:24.04`) that does not exist in the upstream registry. Both the post-merge CI run and a local build attempt failed at the docker pull step. Tracked in [streamspace-templates#3](https://github.com/streamspace-dev/streamspace-templates/issues/3). The `chrome-selkies` Dockerfile needs to be rewritten `FROM ubuntu:24.04` and install Selkies from the [release tarballs](https://github.com/selkies-project/selkies/releases) before any image becomes available.
+>
+> The Helm chart's seeded `default-apps-configmap.yaml` and the example session above point at `ghcr.io/streamspace-dev/chrome-selkies:latest` ahead of when it actually exists; deploys will pull-fail until the build is fixed.
 
-A Selkies-native catalog (Firefox, VS Code, full desktops, etc.) is being added on top of the build pipeline.
+A Selkies-native catalog (Firefox, VS Code, full desktops, etc.) is being added on top of the same pipeline.
 
 ## Development
 


### PR DESCRIPTION
## Summary

The README claimed `chrome-selkies` is the current bootstrap image. **It isn't published.** Local build + both CI runs since [streamspace-templates#2](https://github.com/streamspace-dev/streamspace-templates/pull/2) have failed at the docker pull step because the Dockerfile uses `FROM ghcr.io/selkies-project/selkies-gstreamer:24.04`, which doesn't exist in the upstream registry.

Tracked in [streamspace-templates#3](https://github.com/streamspace-dev/streamspace-templates/issues/3).

## What changed

A `!WARNING` block was added to the "Available applications" section of the README that:

- States plainly that no image is published yet
- Cites the broken base image as the root cause
- Links to the upstream tracking issue
- Calls out that the Helm chart's seeded `default-apps-configmap.yaml` and the example Session in the Quick Start point at the unpublished tag, so deploys will pull-fail until the build is fixed

No code changes — this is purely truth-in-advertising. The architecture, the pipeline shape, and the rest of the README are still correct.

## Why a warning instead of a fix

Fixing the Dockerfile is real engineering work — the rewrite needs to mirror the upstream `docker-nvidia-egl-desktop` Dockerfile (download release tarballs, install the Python wheel, unpack web assets) and then be tested end-to-end with a working browser stream. That belongs in its own focused PR with verified local + CI testing, not the tail of this docs sweep.
