### PR TITLE
fix(ui): audit batch — auth, sessions, settings, admin pages, mocks

### DIFF
--- a/ui/src/components/QuotaCard.tsx
+++ b/ui/src/components/QuotaCard.tsx
@@ -16,8 +16,6 @@ import {
   Workspaces as SessionsIcon,
   Warning as WarningIcon,
 } from '@mui/icons-material';
-import type { UserQuota as _UserQuota } from '../lib/api';
-void (_UserQuota); // Type-only import marked as used
 import { useCurrentUserQuota } from '../hooks/useApi';
 
 interface QuotaMetric {

--- a/ui/src/lib/toast.ts
+++ b/ui/src/lib/toast.ts
@@ -10,6 +10,16 @@ interface ToastOptions {
 class ToastManager {
   private container: HTMLElement | null = null;
   private toasts: Map<string, { element: HTMLElement; timeout: ReturnType<typeof setTimeout> }> = new Map();
+  // Dedupe identical toast messages fired within this window. Without this,
+  // a single page navigation that triggers N parallel API requests all
+  // returning 5xx (e.g. Sessions page hitting /sessions/:id/connect plus
+  // /users/me/quota during a brief backend hiccup) stacks the same red
+  // "Server error. Please try again later." 3-4× simultaneously, which
+  // looks like the app is dying. 2 seconds is long enough to absorb a
+  // request burst but short enough that a real second occurrence still
+  // shows up.
+  private recentMessages: Map<string, number> = new Map();
+  private static readonly DEDUPE_WINDOW_MS = 2000;
 
   private ensureContainer() {
     if (!this.container) {
@@ -57,6 +67,23 @@ class ToastManager {
   }
 
   show(message: string, type: ToastType = 'info', options: ToastOptions = {}) {
+    // Dedupe: skip if this exact message was shown within the recent window.
+    // Keyed by `${type}:${message}` so an info and an error with the same
+    // text are still both shown.
+    const dedupeKey = `${type}:${message}`;
+    const now = Date.now();
+    const last = this.recentMessages.get(dedupeKey);
+    if (last && now - last < ToastManager.DEDUPE_WINDOW_MS) {
+      return null;
+    }
+    this.recentMessages.set(dedupeKey, now);
+    // Garbage-collect old entries so the map doesn't grow unbounded.
+    for (const [key, ts] of this.recentMessages) {
+      if (now - ts > ToastManager.DEDUPE_WINDOW_MS * 2) {
+        this.recentMessages.delete(key);
+      }
+    }
+
     const container = this.ensureContainer();
     const id = `toast-${Date.now()}-${Math.random()}`;
     const duration = options.duration || 4000;

--- a/ui/src/mocks/handlers.ts
+++ b/ui/src/mocks/handlers.ts
@@ -44,8 +44,8 @@ export const MOCK_SESSIONS = {
     },
     activeConnections: 0,
     resources: { cpu: '500m', memory: '2Gi' },
-    created_at: new Date().toISOString(),
-    last_activity: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    lastActivity: new Date().toISOString(),
   },
   hibernated: {
     name: 'test-session-hibernated',
@@ -61,8 +61,8 @@ export const MOCK_SESSIONS = {
     },
     activeConnections: 0,
     resources: { cpu: '500m', memory: '2Gi' },
-    created_at: new Date().toISOString(),
-    last_activity: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    lastActivity: new Date().toISOString(),
   },
 };
 
@@ -189,7 +189,7 @@ export const handlers = [
       ...MOCK_SESSIONS.running,
       name: body.name || `session-${Date.now()}`,
       template: body.template,
-      created_at: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
     };
     return HttpResponse.json(newSession, { status: 201 });
   }),
@@ -293,9 +293,29 @@ export const handlers = [
     });
   }),
 
+  // Cluster metrics — backs admin Dashboard's `useMetrics()` (api.getMetrics → GET /metrics).
+  // Shape mirrors the ClusterMetrics interface declared in admin/Dashboard.tsx.
+  http.get('/api/v1/metrics', () => {
+    return HttpResponse.json({
+      cluster: {
+        nodes: { total: 3, ready: 3, notReady: 0 },
+        sessions: { total: 2, running: 1, hibernated: 1, terminated: 0 },
+        resources: {
+          cpu: { total: '12 cores', used: '3.2 cores', percent: 27 },
+          memory: { total: '48 GiB', used: '14.5 GiB', percent: 30 },
+          pods: { total: 110, used: 28, percent: 25 },
+        },
+        users: { total: 2, active: 1 },
+      },
+    });
+  }),
+
   // Users (admin)
+  // Real backend returns the {users, total} envelope (see api.listUsers); a bare
+  // array would deserialize as `[]` and the page would show "No users found".
   http.get('/api/v1/users', () => {
-    return HttpResponse.json([MOCK_USERS.admin, MOCK_USERS.testuser]);
+    const users = [MOCK_USERS.admin, MOCK_USERS.testuser];
+    return HttpResponse.json({ users, total: users.length });
   }),
 
   // System metrics (admin)
@@ -341,6 +361,11 @@ export const handlers = [
   http.get('/api/v1/admin/nodes', () => HttpResponse.json([])),
   http.get('/api/v1/admin/nodes/stats', () => HttpResponse.json({})),
   http.get('/api/v1/admin/quotas', () => HttpResponse.json([])),
+  // Admin Agents page hits /admin/agents (not /agents) and expects the
+  // {agents, total, page, limit} envelope; bare array → 500 in axios layer.
+  http.get('/api/v1/admin/agents', () =>
+    HttpResponse.json({ agents: MOCK_AGENTS, total: MOCK_AGENTS.length, page: 1, limit: 50 })
+  ),
   http.get('/api/v1/integrations/external', () => HttpResponse.json([])),
   http.get('/api/v1/integrations/webhooks', () => HttpResponse.json([])),
   http.get('/api/v1/integrations/events', () => HttpResponse.json([])),

--- a/ui/src/mocks/handlers.ts
+++ b/ui/src/mocks/handlers.ts
@@ -117,9 +117,15 @@ export const handlers = [
   http.post('/api/v1/auth/login', async ({ request }) => {
     const body = await request.json() as { username: string; password: string };
 
+    // 24h expiry — matches what real backend returns; without this the
+    // auth store's isTokenExpired() returns true (null/undefined treated
+    // as already expired) and route guards bounce back to /login.
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+
     if (body.username === 'admin' && body.password === 'admin123') {
       return HttpResponse.json({
         token: generateMockToken(MOCK_USERS.admin),
+        expiresAt,
         user: MOCK_USERS.admin,
       });
     }
@@ -127,6 +133,7 @@ export const handlers = [
     if (body.username === 'testuser' && body.password === 'testuser123') {
       return HttpResponse.json({
         token: generateMockToken(MOCK_USERS.testuser),
+        expiresAt,
         user: MOCK_USERS.testuser,
       });
     }
@@ -149,13 +156,15 @@ export const handlers = [
     return HttpResponse.json({ message: 'Logged out successfully' });
   }),
 
-  // Sessions endpoints
+  // Sessions endpoints. The real backend wraps the list in
+  // {"sessions": [...], "total": N} (see api/internal/api/handlers.go's
+  // ListSessions); this mock has to match that envelope or api.listSessions()
+  // returns undefined and the page silently renders empty.
+  // (Earlier bug: MOCK_SESSIONS.vnc was referenced here but never defined,
+  // producing a trailing `null` in the array; removed.)
   http.get('/api/v1/sessions', () => {
-    return HttpResponse.json([
-      MOCK_SESSIONS.running,
-      MOCK_SESSIONS.hibernated,
-      MOCK_SESSIONS.vnc,
-    ]);
+    const sessions = [MOCK_SESSIONS.running, MOCK_SESSIONS.hibernated];
+    return HttpResponse.json({ sessions, total: sessions.length });
   }),
 
   http.get('/api/v1/sessions/:sessionId', ({ params }) => {
@@ -298,4 +307,49 @@ export const handlers = [
       uptime: '7 days',
     });
   }),
+
+  // ---------------------------------------------------------------------------
+  // Stub handlers — return empty arrays/objects so the UI doesn't crash with
+  // 500s on endpoints that aren't yet fully mocked. Pages that depend on these
+  // will render their empty states; that's the right behavior for a UI audit
+  // pass focused on layout/interaction bugs.
+  // ---------------------------------------------------------------------------
+  http.get('/api/v1/applications/user', () => HttpResponse.json([])),
+  http.get('/api/v1/preferences/favorites', () => HttpResponse.json([])),
+  http.put('/api/v1/preferences/favorites', () => HttpResponse.json({ success: true })),
+  http.get('/api/v1/plugins', () => HttpResponse.json([])),
+  http.get('/api/v1/plugins/catalog', () => HttpResponse.json([])),
+  http.get('/api/v1/catalog/repositories', () => HttpResponse.json([])),
+  http.get('/api/v1/catalog/templates', () => HttpResponse.json([])),
+  http.get('/api/v1/sessions/by-tags', () => HttpResponse.json([])),
+  http.get('/api/v1/groups', () => HttpResponse.json([])),
+  http.get('/api/v1/users/me', () => HttpResponse.json(MOCK_USERS.admin)),
+  http.get('/api/v1/users/me/quota', () => HttpResponse.json({
+    maxSessions: 10, usedSessions: 1, maxCpu: '8000m', usedCpu: '1000m',
+    maxMemory: '16Gi', usedMemory: '2Gi', maxStorage: '100Gi', usedStorage: '5Gi',
+  })),
+  http.get('/api/v1/scheduling/sessions', () => HttpResponse.json([])),
+  http.get('/api/v1/scheduling/calendar/integrations', () => HttpResponse.json([])),
+  http.get('/api/v1/security/mfa/methods', () => HttpResponse.json([])),
+  http.get('/api/v1/security/ip-whitelist', () => HttpResponse.json([])),
+  http.get('/api/v1/security/alerts', () => HttpResponse.json([])),
+  http.get('/api/v1/security/device-posture', () => HttpResponse.json({})),
+  http.get('/api/v1/compliance/dashboard', () => HttpResponse.json({})),
+  http.get('/api/v1/compliance/policies', () => HttpResponse.json([])),
+  http.get('/api/v1/compliance/violations', () => HttpResponse.json([])),
+  http.get('/api/v1/compliance/frameworks', () => HttpResponse.json([])),
+  http.get('/api/v1/admin/nodes', () => HttpResponse.json([])),
+  http.get('/api/v1/admin/nodes/stats', () => HttpResponse.json({})),
+  http.get('/api/v1/admin/quotas', () => HttpResponse.json([])),
+  http.get('/api/v1/integrations/external', () => HttpResponse.json([])),
+  http.get('/api/v1/integrations/webhooks', () => HttpResponse.json([])),
+  http.get('/api/v1/integrations/events', () => HttpResponse.json([])),
+  http.get('/api/v1/scaling/autoscaling/policies', () => HttpResponse.json([])),
+  http.get('/api/v1/scaling/autoscaling/history', () => HttpResponse.json([])),
+  http.get('/api/v1/scaling/load-balancing/nodes', () => HttpResponse.json([])),
+  http.get('/api/v1/scaling/load-balancing/policies', () => HttpResponse.json([])),
+  http.get('/api/v1/auth/setup/status', () => HttpResponse.json({ setupComplete: true })),
+  http.get('/api/v1/version', () => HttpResponse.json({ version: 'dev' })),
+  http.get('/api/v1/health', () => HttpResponse.json({ status: 'ok' })),
+  http.get('/api/v1/metrics', () => HttpResponse.json({})),
 ];

--- a/ui/src/mocks/handlers.ts
+++ b/ui/src/mocks/handlers.ts
@@ -198,7 +198,9 @@ export const handlers = [
     return HttpResponse.json({ status: 'terminated' });
   }),
 
-  http.post('/api/v1/sessions/:sessionId/connect', () => {
+  // Backend route is GET /sessions/:id/connect (see api/cmd/main.go:637); the
+  // earlier POST mock 500'd in the SessionViewer flow.
+  http.get('/api/v1/sessions/:sessionId/connect', () => {
     return HttpResponse.json({
       connectionId: `conn-${Date.now()}`,
       sessionUrl: 'http://test.local:3000',

--- a/ui/src/pages/Sessions.tsx
+++ b/ui/src/pages/Sessions.tsx
@@ -331,25 +331,45 @@ export default function Sessions() {
               <Grid item xs={12} md={6} lg={4} key={session.name}>
                 <Card>
                   <CardContent>
-                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'start', mb: 2 }}>
-                      <Box>
-                        <Typography variant="h6" sx={{ fontWeight: 600 }}>
+                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 2, gap: 1 }}>
+                      <Box sx={{ minWidth: 0, flex: 1 }}>
+                        <Typography
+                          variant="h6"
+                          sx={{
+                            fontWeight: 600,
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                          title={session.template}
+                        >
                           {session.template}
                         </Typography>
-                        <Typography variant="caption" color="text.secondary">
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{
+                            display: 'block',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                          title={session.name}
+                        >
                           {session.name}
                         </Typography>
                       </Box>
-                      <Box sx={{ display: 'flex', gap: 0.5, flexDirection: 'column', alignItems: 'flex-end' }}>
-                        <Chip label={session.state} size="small" color={getStateColor(session.state)} />
-                        <Chip label={session.status.phase} size="small" color={getPhaseColor(session.status.phase)} />
-                        <ActivityIndicator
-                          isActive={session.isActive}
-                          isIdle={session.isIdle}
-                          state={session.state}
-                          size="small"
-                        />
-                      </Box>
+                      {/* Single status pill — phase is the most informative
+                          (Running/Pending/Hibernated/Failed); the lowercase
+                          `state` Chip and a separate ActivityIndicator pill
+                          were stacked here previously, three pills for the
+                          same conceptual thing. ActivityIndicator now only
+                          appears inline below when the session is idle. */}
+                      <Chip
+                        label={session.status.phase || session.state}
+                        size="small"
+                        color={getPhaseColor(session.status.phase) || getStateColor(session.state)}
+                      />
                     </Box>
 
                     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
@@ -381,13 +401,37 @@ export default function Sessions() {
                         </Box>
                       )}
                       {session.status.url && (
-                        <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                          <Typography variant="body2" color="text.secondary">
+                        <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1, minWidth: 0 }}>
+                          <Typography variant="body2" color="text.secondary" sx={{ flexShrink: 0 }}>
                             URL
                           </Typography>
-                          <Typography variant="body2" sx={{ fontSize: '0.75rem', maxWidth: '60%' }} noWrap>
+                          <Typography
+                            variant="body2"
+                            sx={{
+                              fontSize: '0.75rem',
+                              minWidth: 0,
+                              flex: 1,
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                              whiteSpace: 'nowrap',
+                              textAlign: 'right',
+                            }}
+                            title={session.status.url}
+                          >
                             {session.status.url}
                           </Typography>
+                        </Box>
+                      )}
+                      {/* Idle indicator only when actively idle — not as a
+                          third stacked status pill. */}
+                      {session.isIdle && session.state === 'running' && (
+                        <Box sx={{ display: 'flex', justifyContent: 'flex-start' }}>
+                          <ActivityIndicator
+                            isActive={session.isActive}
+                            isIdle={session.isIdle}
+                            state={session.state}
+                            size="small"
+                          />
                         </Box>
                       )}
                       {session.tags && session.tags.length > 0 && (
@@ -404,8 +448,13 @@ export default function Sessions() {
                       )}
                     </Box>
                   </CardContent>
-                  <CardActions sx={{ justifyContent: 'space-between', px: 2, pb: 2 }}>
-                    <Box>
+                  {/* Action row: previously wrapped inconsistently (Connect on
+                      its own line on narrow cards). flexWrap + gap keeps the
+                      primary action (Connect/Resume) and the icon row on the
+                      same line at sensible card widths and wraps cleanly when
+                      they don't fit. */}
+                  <CardActions sx={{ justifyContent: 'space-between', px: 2, pb: 2, flexWrap: 'wrap', gap: 1 }}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                       {session.state === 'running' ? (
                         <>
                           <Button
@@ -421,6 +470,7 @@ export default function Sessions() {
                             color="warning"
                             onClick={() => handleStateChange(session.name, 'hibernated')}
                             disabled={updateSessionState.isPending}
+                            title="Hibernate"
                           >
                             <PauseIcon />
                           </IconButton>
@@ -431,12 +481,13 @@ export default function Sessions() {
                           color="success"
                           onClick={() => handleStateChange(session.name, 'running')}
                           disabled={updateSessionState.isPending}
+                          title="Resume"
                         >
                           <PlayIcon />
                         </IconButton>
                       )}
                     </Box>
-                    <Box>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                       <IconButton
                         size="small"
                         color="primary"

--- a/ui/src/pages/Sessions.tsx
+++ b/ui/src/pages/Sessions.tsx
@@ -35,7 +35,7 @@ import SessionInvitationDialog from '../components/SessionInvitationDialog';
 import QuotaAlert from '../components/QuotaAlert';
 import ActivityIndicator from '../components/ActivityIndicator';
 import IdleTimer from '../components/IdleTimer';
-import { useUpdateSessionState, useDeleteSession } from '../hooks/useApi';
+import { useSessions, useUpdateSessionState, useDeleteSession } from '../hooks/useApi';
 import { useSessionsWebSocket } from '../hooks/useWebSocket';
 import { useUserStore } from '../store/userStore';
 import { Session } from '../lib/api';
@@ -95,6 +95,10 @@ export default function Sessions() {
   const navigate = useNavigate();
   const username = useUserStore((state) => state.user?.username);
   const [sessions, setSessions] = useState<Session[]>([]);
+  // Initial REST fetch — seeds `sessions` so the page isn't blank during the
+  // window between mount and the first WebSocket push (or forever if the WS
+  // can't connect, which used to leave Sessions silently empty).
+  const { data: initialSessions } = useSessions(username);
   const updateSessionState = useUpdateSessionState();
   const deleteSession = useDeleteSession();
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -140,6 +144,20 @@ export default function Sessions() {
 
   // Enhanced WebSocket with connection quality and manual reconnect
   const sessionsWs = useEnhancedWebSocket(baseSessionsWs);
+
+  // Seed sessions from the initial REST fetch on mount. We only set if local
+  // state is still empty so a faster WebSocket push wins the race; if WS never
+  // connects (mock mode, network glitch), the page still renders the data we
+  // got from REST instead of being permanently empty.
+  useEffect(() => {
+    if (initialSessions && sessions.length === 0) {
+      const filtered = username
+        ? initialSessions.filter((s) => s.user === username)
+        : initialSessions;
+      setSessions(filtered);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialSessions]);
 
   const handleStateChange = (id: string, state: 'running' | 'hibernated') => {
     updateSessionState.mutate({ id, state });
@@ -297,8 +315,15 @@ export default function Sessions() {
             No sessions found with the selected tag. Clear the filter to see all sessions.
           </Alert>
         ) : sessions.length === 0 ? (
-          <Alert severity="info">
-            You don't have any sessions yet. Visit the Template Catalog to create one!
+          <Alert
+            severity="info"
+            action={
+              <Button color="inherit" size="small" onClick={() => navigate('/')}>
+                Browse Applications
+              </Button>
+            }
+          >
+            You don't have any sessions yet. Pick an application to launch one.
           </Alert>
         ) : (
           <Grid container spacing={3}>

--- a/ui/src/store/userStore.ts
+++ b/ui/src/store/userStore.ts
@@ -25,12 +25,23 @@ export const useUserStore = create<AuthState>()(
       expiresAt: null,
       isAuthenticated: false,
 
-      // Set authentication from login response
+      // Set authentication from login response.
+      //
+      // Defensive default for expiresAt: TypeScript marks LoginResponse.expiresAt
+      // as required, but TS type contracts aren't enforced at the network
+      // boundary. A backend (or MSW mock) returning {token, user} without
+      // expiresAt would otherwise leave the field undefined, isTokenExpired()
+      // would return true on the next render, and the route guard would bounce
+      // the user back to /login with no error shown — silent broken auth.
+      // Default to 24h ahead so the session is at least usable until the next
+      // /auth/me call refreshes state.
       setAuth: (loginResponse: LoginResponse) =>
         set({
           user: loginResponse.user,
           token: loginResponse.token,
-          expiresAt: loginResponse.expiresAt,
+          expiresAt:
+            loginResponse.expiresAt ??
+            new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
           isAuthenticated: true,
         }),
 


### PR DESCRIPTION
## Summary

Live-walk audit of every UI route through MSW + Playwright surfaced 5 distinct bugs ranging from a P0 page-killer to mock-data fidelity gaps. All fixed in this batch:

| Commit | What broke |
|---|---|
| \`2f5174b\` | Login → blank page. \`LoginResponse.expiresAt\` was required in TS but the mock omitted it; \`isTokenExpired()\` returned true on undefined and the route guard immediately bounced back to /login. Defensive 24h fallback in \`userStore.setAuth\` so stack/mock contract drift can't silently break auth. |
| \`351c4b8\` | Sessions cards: 3 stacked status pills (state Chip + phase Chip + ActivityIndicator) all showing the same conceptual state, plus title/URL overflow with no ellipsis, plus inconsistent action-row wrapping. Consolidated to single phase pill, proper flex ellipsis (\`minWidth: 0\` + \`textOverflow: ellipsis\`), \`flexWrap: wrap\` on actions. |
| \`26cd2b8\` | **Settings page 100% dead.** \`QuotaCard.tsx\` did \`import type { UserQuota as _UserQuota }\` then \`void(_UserQuota)\` to silence an unused-import lint. Type-only imports get erased at runtime, so \`_UserQuota\` was undefined and the \`void\` expression threw \`ReferenceError\` — caught by ErrorBoundary, killing the whole route. Removed the dead import. |
| \`c743a26\` | Admin Dashboard, admin Users, and Recent Sessions table all broken via three separate mock contract gaps: missing \`/api/v1/metrics\` handler (Dashboard "Failed to load metrics"), bare-array \`/users\` response vs \`{users,total}\` envelope (Users "No users found"), \`created_at\` snake_case vs \`createdAt\` camelCase in MOCK_SESSIONS (Recent Sessions "Invalid Date"). Plus added missing \`/admin/agents\` handler. |
| \`ac2e9fe\` | SessionViewer dead with "Failed to connect to session". Mock was POST for \`/sessions/:id/connect\` but the backend route (api/cmd/main.go:637) is GET. Switched mock to GET. |

## Verification

Walked all major routes in Playwright after each fix:
- ✅ /, /sessions, /shared-sessions, /settings, /sessions/:id/viewer
- ✅ /admin/{dashboard,nodes,users,agents,audit,monitoring,compliance,plugins,scaling,license,recordings,integrations}

All routes render without ErrorBoundary catches.

## Out of scope

Three known cosmetic issues noted but not fixed (low priority):
- Admin Dashboard \`formatBytes('14.5 GiB')\` shows "14B / 48B" — needs raw-byte strings from backend
- Agents table mixes \`lastHeartbeat\` and \`last_heartbeat\` references
- License page feature labels render "Saml Sso", "Mfa" — need acronym casing

## Test plan

- [ ] CI passes
- [ ] Manual: login form works with admin/admin123 (or whatever seed credentials)
- [ ] Manual: navigate to /settings — no ErrorBoundary
- [ ] Manual (with MSW \`?msw=true\`): every admin/* page renders the data, not error toast